### PR TITLE
feat: add drag-and-drop notes with error toast

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "spanish-notes-app",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/utilities": "^3.2.2",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-slot": "^1.2.4",
@@ -803,6 +805,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "pages:build": "npx @cloudflare/next-on-pages"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/utilities": "^3.2.2",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-slot": "^1.2.4",

--- a/src/components/DraggableNote.tsx
+++ b/src/components/DraggableNote.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useDraggable } from '@dnd-kit/core';
+import { CSS } from '@dnd-kit/utilities';
+import Link from 'next/link';
+import { Note } from '@/types/note';
+import { UNTITLED_NOTE_TITLE } from '@/constants';
+
+interface DraggableNoteProps {
+  note: Note;
+}
+
+export default function DraggableNote({ note }: DraggableNoteProps) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
+    id: note.id,
+    data: {
+      type: 'note',
+      note,
+    },
+  });
+
+  const style = {
+    transform: CSS.Translate.toString(transform),
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      data-testid="draggable-note"
+      {...listeners}
+      {...attributes}
+    >
+      <Link
+        href={`/?noteId=${note.id}`}
+        className="block p-2 rounded-lg text-slate-400 hover:bg-slate-800 hover:text-white transition-colors truncate text-sm cursor-grab active:cursor-grabbing"
+      >
+        {note.title || UNTITLED_NOTE_TITLE}
+      </Link>
+    </div>
+  );
+}

--- a/src/components/DroppableFolder.tsx
+++ b/src/components/DroppableFolder.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useDroppable } from '@dnd-kit/core';
+import { ChevronDown, ChevronRight, Folder as FolderIcon } from 'lucide-react';
+import { Folder } from '@/types/folder';
+import { clsx } from 'clsx';
+
+interface DroppableFolderProps {
+  folder: Folder;
+  isExpanded: boolean;
+  onToggle: (folderId: string) => void;
+  noteCount: number;
+  children: React.ReactNode;
+}
+
+export default function DroppableFolder({
+  folder,
+  isExpanded,
+  onToggle,
+  noteCount,
+  children
+}: DroppableFolderProps) {
+  const { isOver, setNodeRef } = useDroppable({
+    id: folder.id,
+    data: {
+      type: 'folder',
+      folder,
+    },
+  });
+
+  return (
+    <div ref={setNodeRef} data-testid="droppable-folder">
+      <button
+        onClick={() => onToggle(folder.id)}
+        className={clsx(
+          "w-full flex items-center gap-2 p-2 rounded-lg transition-colors",
+          isOver ? "bg-slate-700 text-white" : "text-slate-300 hover:bg-slate-800 hover:text-white"
+        )}
+      >
+        {isExpanded ? (
+          <ChevronDown className="w-4 h-4" />
+        ) : (
+          <ChevronRight className="w-4 h-4" />
+        )}
+        <FolderIcon className="w-4 h-4" />
+        <span className="flex-1 text-left truncate">{folder.name}</span>
+        <span className="text-xs text-slate-500">{noteCount}</span>
+      </button>
+
+      {isExpanded && (
+        <div className="ml-6 space-y-1">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/FolderList.tsx
+++ b/src/components/FolderList.tsx
@@ -1,11 +1,14 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import Link from 'next/link';
+import { DndContext, DragEndEvent } from '@dnd-kit/core';
 import { Folder } from '@/types/folder';
 import { Note } from '@/types/note';
 import { UNTITLED_NOTE_TITLE } from '@/constants';
-import { ChevronDown, ChevronRight, Folder as FolderIcon } from 'lucide-react';
+import { moveNote } from '@/utils/notes/actions';
+import DroppableFolder from './DroppableFolder';
+import DraggableNote from './DraggableNote';
 
 interface FolderListProps {
   folders: Folder[];
@@ -17,6 +20,11 @@ export default function FolderList({ folders, notes, showHierarchy = true }: Fol
   const [expandedFolders, setExpandedFolders] = useState<Set<string>>(
     new Set(folders.map(f => f.id))
   );
+  const [isClient, setIsClient] = useState(false);
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
 
   const notesByFolder = useMemo(() => {
     const map = new Map<string, Note[]>();
@@ -47,6 +55,27 @@ export default function FolderList({ folders, notes, showHierarchy = true }: Fol
     return notesByFolder.get(folderId) || [];
   };
 
+  const handleDragEnd = async (event: DragEndEvent) => {
+    const { active, over } = event;
+
+    if (!over) return;
+
+    const noteId = active.id as string;
+    const folderId = over.id as string;
+
+    if (active.data.current?.type === 'note' && over.data.current?.type === 'folder') {
+      const note = active.data.current.note as Note;
+      
+      if (note.folder_id === folderId) return;
+
+      try {
+        await moveNote(noteId, folderId);
+      } catch (error) {
+        console.error('Failed to move note:', error);
+      }
+    }
+  };
+
   if (!showHierarchy) {
     return (
       <div className="space-y-1">
@@ -63,44 +92,36 @@ export default function FolderList({ folders, notes, showHierarchy = true }: Fol
     );
   }
 
-  return (
+  const folderTree = (
     <div className="space-y-1">
       {folders.map(folder => {
         const folderNotes = getNotesForFolder(folder.id);
         const isExpanded = expandedFolders.has(folder.id);
 
         return (
-          <div key={folder.id}>
-            <button
-              onClick={() => toggleFolder(folder.id)}
-              className="w-full flex items-center gap-2 p-2 rounded-lg text-slate-300 hover:bg-slate-800 hover:text-white transition-colors"
-            >
-              {isExpanded ? (
-                <ChevronDown className="w-4 h-4" />
-              ) : (
-                <ChevronRight className="w-4 h-4" />
-              )}
-              <FolderIcon className="w-4 h-4" />
-              <span className="flex-1 text-left truncate">{folder.name}</span>
-              <span className="text-xs text-slate-500">{folderNotes.length}</span>
-            </button>
-
-            {isExpanded && (
-              <div className="ml-6 space-y-1">
-                {folderNotes.map(note => (
-                  <Link
-                    key={note.id}
-                    href={`/?noteId=${note.id}`}
-                    className="block p-2 rounded-lg text-slate-400 hover:bg-slate-800 hover:text-white transition-colors truncate text-sm"
-                  >
-                    {note.title || UNTITLED_NOTE_TITLE}
-                  </Link>
-                ))}
-              </div>
-            )}
-          </div>
+          <DroppableFolder
+            key={folder.id}
+            folder={folder}
+            isExpanded={isExpanded}
+            onToggle={toggleFolder}
+            noteCount={folderNotes.length}
+          >
+            {folderNotes.map(note => (
+              <DraggableNote key={note.id} note={note} />
+            ))}
+          </DroppableFolder>
         );
       })}
     </div>
+  );
+
+  if (!isClient) {
+    return folderTree;
+  }
+
+  return (
+    <DndContext onDragEnd={handleDragEnd}>
+      {folderTree}
+    </DndContext>
   );
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -11,6 +11,7 @@ import CreateFolderDialog from './CreateFolderDialog';
 import { shouldShowHierarchy } from '@/utils/folders/display';
 import { createFolder } from '@/utils/folders/actions';
 import { FolderPlus } from 'lucide-react';
+import { ToastProvider, Toast, ToastViewport, ToastTitle, ToastDescription, ToastClose } from './Toast';
 
 interface SidebarProps {
   notes: Note[];
@@ -20,15 +21,23 @@ interface SidebarProps {
 
 export default function Sidebar({ notes, folders, profile }: SidebarProps) {
   const [isCreateFolderOpen, setIsCreateFolderOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const showHierarchy = shouldShowHierarchy(folders);
 
   const handleCreateFolder = async (name: string) => {
-    await createFolder(name);
-    setIsCreateFolderOpen(false);
+    setError(null);
+    try {
+      await createFolder(name);
+      setIsCreateFolderOpen(false);
+    } catch (error) {
+      console.error('Failed to create folder:', error);
+      setError(error instanceof Error ? error.message : 'Failed to create folder');
+    }
   };
 
   return (
-    <aside className="w-64 border-r border-slate-700 bg-slate-900 h-screen flex flex-col flex-shrink-0">
+    <ToastProvider>
+      <aside className="w-64 border-r border-slate-700 bg-slate-900 h-screen flex flex-col flex-shrink-0">
       <div className="p-4 border-b border-slate-700">
         <h2 className="text-xl font-bold text-slate-100 mb-4">My Notes</h2>
         <CreateNoteButton isActive={profile?.is_active || false} />
@@ -56,6 +65,16 @@ export default function Sidebar({ notes, folders, profile }: SidebarProps) {
         onClose={() => setIsCreateFolderOpen(false)}
         onCreate={handleCreateFolder}
       />
+
+      <Toast open={!!error} onOpenChange={() => setError(null)}>
+        <div className="grid gap-1">
+          <ToastTitle>Error</ToastTitle>
+          <ToastDescription>{error}</ToastDescription>
+        </div>
+        <ToastClose />
+      </Toast>
+      <ToastViewport />
     </aside>
+    </ToastProvider>
   );
 }

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import * as React from 'react';
+import * as ToastPrimitives from '@radix-ui/react-toast';
+import { X } from 'lucide-react';
+import { clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: (string | undefined | null | false)[]) {
+  return twMerge(clsx(inputs));
+}
+
+export const ToastProvider = ToastPrimitives.Provider;
+
+export const ToastViewport = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Viewport>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Viewport
+    ref={ref}
+    className={cn(
+      "fixed bottom-0 right-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      className
+    )}
+    {...props}
+  />
+));
+ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
+
+export const Toast = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Root
+    ref={ref}
+    className={cn(
+      "group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border border-slate-700 bg-slate-800 p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
+      className
+    )}
+    {...props}
+  />
+));
+Toast.displayName = ToastPrimitives.Root.displayName;
+
+export const ToastTitle = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Title>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Title
+    ref={ref}
+    className={cn("text-sm font-semibold text-slate-100", className)}
+    {...props}
+  />
+));
+ToastTitle.displayName = ToastPrimitives.Title.displayName;
+
+export const ToastDescription = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Description>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Description
+    ref={ref}
+    className={cn("text-sm opacity-90 text-slate-300", className)}
+    {...props}
+  />
+));
+ToastDescription.displayName = ToastPrimitives.Description.displayName;
+
+export const ToastClose = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Close>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Close>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Close
+    ref={ref}
+    className={cn(
+      "absolute right-2 top-2 rounded-md p-1 text-slate-400 opacity-0 transition-opacity hover:text-slate-100 focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100",
+      className
+    )}
+    toast-close=""
+    {...props}
+  >
+    <X className="h-4 w-4" />
+  </ToastPrimitives.Close>
+));
+ToastClose.displayName = ToastPrimitives.Close.displayName;

--- a/tests/components/folders/DraggableNote.test.tsx
+++ b/tests/components/folders/DraggableNote.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { DndContext } from '@dnd-kit/core';
+import DraggableNote from '@/components/DraggableNote';
+import { UNTITLED_NOTE_TITLE } from '@/constants';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+describe('DraggableNote', () => {
+  const mockNote = {
+    id: 'note-1',
+    title: 'Test Note',
+    folder_id: 'folder-1',
+    user_id: 'user-1',
+    content: '',
+    created_at: '2026-01-01',
+    updated_at: '2026-01-01',
+    is_favorite: false,
+  };
+
+  const renderWithDnd = (ui: React.ReactElement) => {
+    return render(<DndContext>{ui}</DndContext>);
+  };
+
+  it('should render the note title', () => {
+    renderWithDnd(<DraggableNote note={mockNote} />);
+    expect(screen.getByText('Test Note')).toBeInTheDocument();
+  });
+
+  it('should render untitled for notes without title', () => {
+    renderWithDnd(<DraggableNote note={{ ...mockNote, title: '' }} />);
+    expect(screen.getByText(UNTITLED_NOTE_TITLE)).toBeInTheDocument();
+  });
+
+  it('should have draggable data attributes', () => {
+    renderWithDnd(<DraggableNote note={mockNote} />);
+    const element = screen.getByTestId('draggable-note');
+    expect(element).toBeInTheDocument();
+  });
+
+  it('should include note id in the link href', () => {
+    renderWithDnd(<DraggableNote note={mockNote} />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/?noteId=note-1');
+  });
+});

--- a/tests/components/folders/DroppableFolder.test.tsx
+++ b/tests/components/folders/DroppableFolder.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { DndContext } from '@dnd-kit/core';
+import DroppableFolder from '@/components/DroppableFolder';
+
+describe('DroppableFolder', () => {
+  const mockFolder = {
+    id: 'folder-1',
+    name: 'My Notes',
+    is_default: true,
+    user_id: 'user-1',
+    collection_id: 'collection-1',
+    created_at: '2026-01-01',
+  };
+
+  const renderWithDnd = (ui: React.ReactElement) => {
+    return render(<DndContext>{ui}</DndContext>);
+  };
+
+  it('should render the folder name', () => {
+    renderWithDnd(
+      <DroppableFolder folder={mockFolder} isExpanded={true} onToggle={() => {}} noteCount={5}>
+        <div>Child content</div>
+      </DroppableFolder>
+    );
+    expect(screen.getByText('My Notes')).toBeInTheDocument();
+  });
+
+  it('should render note count', () => {
+    renderWithDnd(
+      <DroppableFolder folder={mockFolder} isExpanded={true} onToggle={() => {}} noteCount={5}>
+        <div>Child content</div>
+      </DroppableFolder>
+    );
+    expect(screen.getByText('5')).toBeInTheDocument();
+  });
+
+  it('should render children when expanded', () => {
+    renderWithDnd(
+      <DroppableFolder folder={mockFolder} isExpanded={true} onToggle={() => {}} noteCount={1}>
+        <div>Child note</div>
+      </DroppableFolder>
+    );
+    expect(screen.getByText('Child note')).toBeInTheDocument();
+  });
+
+  it('should NOT render children when collapsed', () => {
+    renderWithDnd(
+      <DroppableFolder folder={mockFolder} isExpanded={false} onToggle={() => {}} noteCount={1}>
+        <div>Child note</div>
+      </DroppableFolder>
+    );
+    expect(screen.queryByText('Child note')).not.toBeInTheDocument();
+  });
+
+  it('should have droppable data attribute', () => {
+    renderWithDnd(
+      <DroppableFolder folder={mockFolder} isExpanded={true} onToggle={() => {}} noteCount={0}>
+        <div>Content</div>
+      </DroppableFolder>
+    );
+    expect(screen.getByTestId('droppable-folder')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Add drag-and-drop support for moving notes between folders
- Prevent hydration mismatch by enabling DnD only on client
- Show error toast when folder creation fails

## Testing
- `npm test -- --run tests/components/folders/DraggableNote.test.tsx tests/components/folders/DroppableFolder.test.tsx tests/components/folders/FolderList.test.tsx`