### PR TITLE
fix(ci): update stale FAQ shell test

### DIFF
--- a/tests/app/faq/page.light.test.tsx
+++ b/tests/app/faq/page.light.test.tsx
@@ -8,12 +8,13 @@ vi.mock('next/headers', () => ({
 }));
 
 describe('FAQ page', () => {
-  it('renders key sections in light mode', async () => {
+  it('renders key sections with the redesigned dark shell', async () => {
     const ui = await FaqPage();
     const { container } = render(ui);
     const root = container.firstChild as HTMLElement;
 
-    expect(root.className).toContain('bg-slate-50');
+    expect(root.className).toContain('bg-[#0A0A0B]');
+    expect(root.className).toContain('text-slate-300');
     expect(screen.getByText(messages.en.faq.title)).toBeInTheDocument();
     expect(screen.getByText(messages.en.faq.howTitle)).toBeInTheDocument();
     expect(screen.getByText(messages.en.faq.sectionTitle)).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- update the stale FAQ page test to match the intentional dark-shell redesign from PR #52
- keep production code unchanged because the CI failure came from an outdated assertion
- document that broader lint/typecheck issues are existing baseline problems, not introduced by this patch

## Files
- tests/app/faq/page.light.test.tsx

## Verification
- npm test -- --run tests/app/faq/page.light.test.tsx
- npm test -- --run
- npm run build
- npm run pages:build
- npm run lint *(fails on existing unrelated baseline issues)*
- npx tsc --noEmit *(fails on existing unrelated baseline issues)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated FAQ page with dark theme styling.

* **Tests**
  * Updated FAQ page tests to validate dark mode rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->