### PR TITLE
feat(share): 在分享页顶部添加品牌引导横幅 (Top Banner)

### DIFF
--- a/src/app/share/[token]/page.tsx
+++ b/src/app/share/[token]/page.tsx
@@ -95,8 +95,22 @@ export default async function SharedNotePage({
   }
 
   return (
-    <div className="min-h-screen bg-slate-50 text-slate-900 dark:bg-slate-950 dark:text-slate-100">
-      <main className="mx-auto max-w-4xl px-4 py-8 md:py-12">
+    <div className="flex min-h-screen flex-col bg-slate-50 text-slate-900 dark:bg-slate-950 dark:text-slate-100">
+      <div className="flex w-full flex-col items-center justify-center gap-2 bg-gradient-to-r from-blue-600 to-indigo-600 px-4 py-3 text-center text-sm font-medium text-white sm:flex-row sm:text-base">
+        <div className="flex items-center gap-2">
+          <span className="hidden sm:inline">⚡</span>
+          <span>{t('share.topBannerText')}</span>
+        </div>
+        <Link
+          href={ROUTES.app}
+          className="group inline-flex items-center gap-1 whitespace-nowrap rounded-full bg-white/20 px-3 py-1 text-xs font-semibold text-white backdrop-blur-sm transition-colors hover:bg-white/30 sm:ml-2 sm:text-sm"
+        >
+          {t('share.topBannerCta')}
+          <span className="transition-transform duration-200 group-hover:translate-x-0.5" aria-hidden="true">→</span>
+        </Link>
+      </div>
+
+      <main className="mx-auto w-full max-w-4xl flex-grow px-4 py-8 md:py-12">
         <ShareUpdateWatcher token={token} initialUpdatedAt={note.updatedAt} />
 
         <div className="mb-4 flex items-center justify-between gap-3">

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -259,6 +259,8 @@ export const messages: Record<Locale, Record<string, Record<string, string>>> = 
       howToUseStep2: 'Use it as a read-only practice page for listening and shadowing.',
       howToUseStep3: 'Want your own workspace? Use the create-notes button.',
       howToUseTip: 'Tip: This shared page is read-only, so edits are not available here.',
+      topBannerText: 'This note was created with VivaNote, a click-to-pronounce language learning app.',
+      topBannerCta: 'Create your notes for free',
     },
   },
   zh: {
@@ -519,6 +521,8 @@ export const messages: Record<Locale, Record<string, Record<string, string>>> = 
       howToUseStep2: '把它当作只读练习页进行听读和跟读。',
       howToUseStep3: '想要自己的工作区？点击创建笔记按钮。',
       howToUseTip: '提示：该分享页为只读模式，无法直接编辑。',
+      topBannerText: '这篇笔记由 VivaNote 创建，一款支持点击文本听发音的语言学习应用。',
+      topBannerCta: '免费创建你的笔记',
     },
   },
 };


### PR DESCRIPTION
# feat(share): 在分享页顶部添加品牌引导横幅 (Top Banner)

## Summary

为了提升分享链接的用户转化效率，在分享页面最顶部加入了一条全宽的品牌引导横幅。

之前的问题：访客通过分享链接打开页面后，唯一的引导入口是右上角一个很小的可展开圆形按钮，且底部的品牌营销卡片在不往下滚动的情况下完全不可见，导致转化路径对访客来说不够直观。

本次改动：在页面最顶部（笔记内容上方）加入一条蓝-靛蓝渐变横幅，访客进入页面后第一眼就能看到 VivaNote 品牌信息以及引导跳转的 CTA 按钮。

## Key Changes

- **`src/app/share/[token]/page.tsx`**
  - 将最外层容器改为 `flex-col`，支持顶部 Banner + 正文的垂直布局
  - 在 `<main>` 上方注入全宽品牌横幅，背景采用蓝色到紫色的渐变（`from-blue-600 to-indigo-600`）
  - 横幅包含品牌说明文案和指向 `ROUTES.app` 的 CTA 按钮（带 hover 动效）
  - 装饰性箭头符号加了 `aria-hidden="true"`，符合无障碍标准

- **`src/i18n/messages.ts`**
  - 在 `en.share` 和 `zh.share` 各新增 `topBannerText` 和 `topBannerCta` 两个 key，支持中英文多语言切换

## How to Test

1. 在本地从任意一条笔记创建分享链接
2. 打开分享链接，确认页面顶部出现蓝色渐变横幅
3. 横幅文案应为："This note was created with VivaNote, a click-to-pronounce language learning app." + "Create your notes for free" 按钮
4. 点击按钮，确认跳转到主应用页面（`/app`）
5. 切换界面语言至中文，确认横幅文案切换为中文版本
6. 在移动端视口尺寸下（< 640px）确认横幅垂直堆叠排列，不影响正文布局
