### PR TITLE
fix(auth): auto-activate Google OAuth users

### DIFF
--- a/supabase/migrations/010_auto_activate_google_oauth_profiles.sql
+++ b/supabase/migrations/010_auto_activate_google_oauth_profiles.sql
@@ -1,0 +1,54 @@
+-- Auto-activate Google OAuth profiles while keeping invite-only email signup.
+--
+-- Email/password signup still goes through the hidden /auth/invite path and
+-- remains protected by enforce_invite_only_email_signup from migration 008.
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER AS $$
+DECLARE
+  new_collection_id uuid;
+  provider text;
+BEGIN
+  provider := COALESCE(NEW.raw_app_meta_data ->> 'provider', '');
+
+  -- Create user profile. Google OAuth users should not need an activation code.
+  INSERT INTO public.user_profiles (id, email, is_active)
+  VALUES (NEW.id, NEW.email, provider = 'google')
+  ON CONFLICT (id) DO NOTHING;
+
+  -- Create default collection
+  INSERT INTO public.collections (user_id, name, is_default)
+  VALUES (NEW.id, 'My Collection', true)
+  RETURNING id INTO new_collection_id;
+
+  -- Create default folder
+  INSERT INTO public.folders (user_id, collection_id, name, is_default)
+  VALUES (NEW.id, new_collection_id, 'My Notes', true);
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE OR REPLACE FUNCTION public.ensure_user_profile()
+RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+BEGIN
+  INSERT INTO public.user_profiles (id, email, is_active)
+  SELECT
+    auth.uid(),
+    u.email,
+    COALESCE(u.raw_app_meta_data ->> 'provider', '') = 'google'
+  FROM auth.users u
+  WHERE u.id = auth.uid()
+  ON CONFLICT (id) DO NOTHING;
+END;
+$$;
+
+-- Backfill existing Google OAuth profiles that were created before this change.
+UPDATE public.user_profiles p
+SET is_active = true
+FROM auth.users u
+WHERE p.id = u.id
+  AND COALESCE(u.raw_app_meta_data ->> 'provider', '') = 'google'
+  AND p.is_active = false;

--- a/tests/supabase/google-oauth-activation-migration.test.ts
+++ b/tests/supabase/google-oauth-activation-migration.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const migrationPath = join(
+  process.cwd(),
+  'supabase/migrations/010_auto_activate_google_oauth_profiles.sql',
+);
+
+describe('Google OAuth activation migration', () => {
+  it('auto-activates Google OAuth profiles without disabling invite-only email signup', () => {
+    const sql = readFileSync(migrationPath, 'utf8');
+
+    expect(sql).toContain("NEW.raw_app_meta_data ->> 'provider'");
+    expect(sql).toContain("= 'google'");
+    expect(sql).toContain('INSERT INTO public.user_profiles (id, email, is_active)');
+    expect(sql).toContain('public.ensure_user_profile');
+    expect(sql).not.toContain('DROP TRIGGER IF EXISTS enforce_invite_only_email_signup');
+    expect(sql).not.toContain('DROP TRIGGER IF EXISTS consume_email_invite_on_signup');
+  });
+});


### PR DESCRIPTION
## Summary
- Auto-activate user profiles created through Google OAuth so Google sign-in users do not need an activation code.
- Preserve hidden email/password invite-only signup by leaving the invite enforcement triggers untouched.
- Backfill existing Google OAuth profiles that are currently inactive.

## Files
- supabase/migrations/010_auto_activate_google_oauth_profiles.sql
- tests/supabase/google-oauth-activation-migration.test.ts

## Verification
- npm test -- tests/supabase/google-oauth-activation-migration.test.ts --run
- npm test -- tests/components/InviteEmailSignupForm.test.tsx --run
- npx eslint src/components/InviteEmailSignupForm.tsx src/i18n/messages.ts tests/supabase/google-oauth-activation-migration.test.ts
- npm test -- --run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Google OAuth users are now automatically activated upon signup
  * Default collections and folders are automatically created for new users
  * Email/password signup remains invite-only protected

* **Tests**
  * Added test to verify Google OAuth activation behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->